### PR TITLE
feat: 푸터 UI 구현 및 공통 링크 스타일 초기화 (#19)

### DIFF
--- a/assets/css/base/layout.css
+++ b/assets/css/base/layout.css
@@ -194,8 +194,9 @@ header .container {
 }
 
 .footer {
+    width: 100%;
     background-color: var(--color-bg-secondary);
-    padding: 6.0rem 0;
+    padding: 3.0rem 0;
 }
 
 /*웹 접근성*/

--- a/assets/css/base/reset.css
+++ b/assets/css/base/reset.css
@@ -84,3 +84,9 @@ input {
     outline: none;       
     background: none;            
 }
+
+a {
+    color: inherit;         
+    text-decoration: none;  
+    cursor: pointer;        
+}

--- a/assets/css/components/footer.css
+++ b/assets/css/components/footer.css
@@ -1,0 +1,50 @@
+.footer-top {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 2.1rem;
+}
+
+.footer-links {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 1.4rem;
+
+    font-family: var(--font-base);
+    font-weight: var(--fw-regular);
+    font-size: var(--fs-sm);
+    color: var(--color-text-base);
+}
+
+.footer-links li:hover,
+.footer-links li:active {
+    font-weight: var(--fw-bold);
+}
+
+.sns-links {
+    display: flex;
+    flex-direction: row;
+    gap: 1.4rem;
+}
+
+.row-divider {
+    width: 100%;
+    height: 0.1rem;
+    margin-bottom: 3.0rem;
+    background-color: var(--color-bg-border);
+}
+
+.footer-info {
+    display: flex;
+    flex-direction: column;
+    gap: 1.0rem;
+
+    font-family: var(--font-base);
+    font-weight: var(--fw-regular);
+    font-size: var(--fs-sm);
+    color: var(--color-text-muted);
+}
+
+.company-name {
+    font-weight: var(--fw-medium);
+}

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="/assets/css/base/layout.css">
     <link rel="stylesheet" href="/assets/css/components/gnb.css" />
     <link rel="stylesheet" href="/assets/css/components/modal.css" />
+    <link rel="stylesheet" href="/assets/css/components/footer.css" />
 </head>
 <body>
     <header>
@@ -150,8 +151,41 @@
 
     <footer class="footer">
         <div class="container">
-            <h2 class="ir">서비스 정보</h2>
-            <p>위니브 정보</p> </div>
+            <div class="footer-top">
+                <ul class="footer-links">
+                    <li><a href="#">호두샵 소개</a></li>
+                    <span class="divider">|</span>
+                    <li><a href="#">이용약관</a></li>
+                    <span class="divider">|</span>
+                    <li><a href="#">개인정보처리방침</a></li>
+                    <span class="divider">|</span>
+                    <li><a href="#">전자금융거래약관</a></li>
+                    <span class="divider">|</span>
+                    <li><a href="#">청소년보호정책</a></li>
+                    <span class="divider">|</span>
+                    <li><a href="#">제휴문의</a></li>
+                </ul>
+                <ol class="sns-links">
+                    <li><button type="button"><img src="/assets/images/icon-insta.svg" alt="인스타그램"></button></li>
+                    <li><button type="button"><img src="/assets/images/icon-fb.svg" alt="페이스북"></button></li>
+                    <li><button type="button"><img src="/assets/images/icon-yt.svg" alt="유튜브"></button></li>
+                </ol>
+            </div>
+
+            <!-- 위 / 아래 구분선 -->
+            <div class="row-divider"></div>
+            
+            <address class="footer-info">
+                <p class="company-name">(주)HODU SHOP</p>
+                <p>제주특별자치도 제주시 동광로 137 제주코딩베이스캠프</p>
+                <div class="biz-info">
+                    <span>사업자 번호 : 000-0000-0000</span>
+                    <span class="divider">|</span>
+                    <span>통신판매업</span>
+                </div>
+                <p>대표 : 김호두</p> 
+            </address>
+        </div>
     </footer>
     <script src="/assets/js/components/gnb.js"></script>
     <script src="/assets/js/components/modal.js"></script>


### PR DESCRIPTION
## 관련 이슈
#19

## 작업 내용
[x] 하단 푸터(Footer) 영역 마크업 및 전체 레이아웃 스타일링 (index.html, footer.css)
[x] SNS 소셜 아이콘 배치 및 사업자 정보/서비스 정보 섹션 구현
[x] reset.css 내 모든 a 태그의 text-decoration: none(밑줄 제거) 공통 스타일 추가
[x] 모바일 및 태블릿 환경을 고려한 푸터 내 반응형 레이아웃 대응

## 스크린샷 (선택)
<img width="1918" height="278" alt="image" src="https://github.com/user-attachments/assets/111b4371-28f1-49d3-86a6-862dc728f94d" />
